### PR TITLE
docs: update CHANGELOG + bump to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to claude-world-examples will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-14
+
+Documentation maintenance and version updates.
+
+### Changed
+- Bumped version badge and timestamps to v1.2.0
+
+---
+
+## [1.1.0] - 2026-03-13
+
+### Added
+- Trend Pulse MCP integration examples (`examples/trend-pulse/`)
+  - Basic trending queries with `get_trending` and `search_trends`
+  - Content brief generation from trending signals
+- CF Browser integration examples (`examples/cf-browser/`)
+  - Screenshot capture and page inspection
+  - JavaScript-rendered page scraping
+- 5 new documentation examples + 2 new guides (designing agents, designing skills)
+- GitHub Actions automation suite template
+
+### Changed
+- Updated model references: Opus/Sonnet 4.5 → 4.6
+
+### Fixed
+- Light mode text visibility in React component examples
+
+---
+
 ## [1.0.0] - 2026-01-13
 
 First official release, synced with [claude-world.com v1.0.0](https://claude-world.com).

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 [![Website](https://img.shields.io/badge/Website-claude--world.com-blue)](https://claude-world.com)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da)](https://discord.gg/rBtHzSD288)
-[![Version](https://img.shields.io/badge/version-1.0.0-green)](https://github.com/claude-world/claude-world-examples/releases/tag/v1.0.0)
+[![Version](https://img.shields.io/badge/version-1.2.0-green)](https://github.com/claude-world/claude-world-examples/releases/tag/v1.2.0)
 
 ---
 
-**🎉 v1.0.0 Released!** Website is now live at [claude-world.com](https://claude-world.com) - built from zero to production in 48 hours using Claude Code + Director Mode.
+**🎉 v1.2.0 Released!** Website is now live at [claude-world.com](https://claude-world.com) - built from zero to production in 48 hours using Claude Code + Director Mode.
 
 ---
 
@@ -231,4 +231,4 @@ MIT License - see [LICENSE](./LICENSE)
 
 Built with Claude Code by the Claude World community.
 
-*Last updated: 2026-01-13*
+*Last updated: 2026-03-14*


### PR DESCRIPTION
## Summary
- Add v1.1.0 changelog entry: trend-pulse/cf-browser examples, model 4.5→4.6 updates
- Add v1.2.0 changelog entry for documentation maintenance
- Update README version badge 1.0.0 → 1.2.0 and last-updated timestamp

## Test plan
- [x] CHANGELOG.md has v1.1.0 and v1.2.0 entries
- [x] README.md badge points to v1.2.0
- [x] README.md last updated shows 2026-03-14