### PR TITLE
fix: replace fake MongoDB credentials with placeholder

### DIFF
--- a/examples/mcp-setup.md
+++ b/examples/mcp-setup.md
@@ -242,7 +242,7 @@ claude mcp add --scope project mongodb \
 
 # MongoDB Atlas
 claude mcp add --scope project mongodb \
-  -e MONGODB_URI="mongodb+srv://user:pass@cluster.mongodb.net/myapp" \
+  -e MONGODB_URI="mongodb+srv://<USER>:<PASSWORD>@cluster.mongodb.net/myapp" \
   -- npx -y @modelcontextprotocol/server-mongodb
 ```
 

--- a/examples/zh-TW/mcp-setup.md
+++ b/examples/zh-TW/mcp-setup.md
@@ -242,7 +242,7 @@ claude mcp add --scope project mongodb \
 
 # MongoDB Atlas
 claude mcp add --scope project mongodb \
-  -e MONGODB_URI="mongodb+srv://user:pass@cluster.mongodb.net/myapp" \
+  -e MONGODB_URI="mongodb+srv://<USER>:<PASSWORD>@cluster.mongodb.net/myapp" \
   -- npx -y @modelcontextprotocol/server-mongodb
 ```
 


### PR DESCRIPTION
## Summary
- Replaces `user:pass` in example MongoDB URI with `<USER>:<PASSWORD>` placeholder
- Resolves secret scanning alert #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)